### PR TITLE
Install Haproxy via Ansible

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
               //   ${env.TERRAFORM_HOME}/terraform destroy -target module.libvirt_domain.libvirt_domain.domain -input=false -auto-approve
               // """
               sh """#!/bin/bash
-                ${env.TERRAFORM_HOME}/terraform apply -input=false -auto-approve
+                ${env.TERRAFORM_HOME}/terraform destroy -input=false -auto-approve
               """
             }
           }
@@ -130,13 +130,13 @@ pipeline {
     //     }
     //   }
     // }
-    stage('Ansible play') {
-      steps {
-        dir('./ansible') {
-          ansiblePlaybook installation: 'ansible', inventory: 'hosts', playbook: 'play/demo.yml', vaultCredentialsId: 'AnsibleVaultPass'
-        }
-      }
-    }
+    // stage('Ansible play') {
+    //   steps {
+    //     dir('./ansible') {
+    //       ansiblePlaybook installation: 'ansible', inventory: 'hosts', playbook: 'play/demo.yml', vaultCredentialsId: 'AnsibleVaultPass'
+    //     }
+    //   }
+    // }
   }
   // post {
   //   always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
               //   ${env.TERRAFORM_HOME}/terraform destroy -target module.libvirt_domain.libvirt_domain.domain -input=false -auto-approve
               // """
               sh """#!/bin/bash
-                ${env.TERRAFORM_HOME}/terraform destroy -input=false -auto-approve
+                ${env.TERRAFORM_HOME}/terraform apply -input=false -auto-approve
               """
             }
           }
@@ -130,13 +130,13 @@ pipeline {
     //     }
     //   }
     // }
-    // stage('Ansible play') {
-    //   steps {
-    //     dir('./ansible') {
-    //       ansiblePlaybook installation: 'ansible', inventory: 'hosts', playbook: 'play/demo.yml', vaultCredentialsId: 'AnsibleVaultPass'
-    //     }
-    //   }
-    // }
+    stage('Ansible play') {
+      steps {
+        dir('./ansible') {
+          ansiblePlaybook installation: 'ansible', inventory: 'hosts', playbook: 'play/demo.yml', vaultCredentialsId: 'AnsibleVaultPass'
+        }
+      }
+    }
   }
   // post {
   //   always {

--- a/ansible/host_vars/bastion/vars.yaml
+++ b/ansible/host_vars/bastion/vars.yaml
@@ -1,7 +1,7 @@
 ---
 
-ansible_ssh_user     : 'fedora'
-ansible_become_pass  : '{{ vault_ansible_become_pass }}'
+ansible_ssh_user     : 'ansible'
+# ansible_become_pass  : '{{ vault_ansible_become_pass }}'
 
 pull_secret          : '{{ vault_pull_secret | to_json }}'
 ssh_key              : '{{ vault_ssh_key }}'

--- a/ansible/play/demo.yml
+++ b/ansible/play/demo.yml
@@ -14,3 +14,7 @@
   - name: Facts
     ansible.builtin.debug:
       var: ansible_facts
+
+  roles:
+  - role: haproxy
+    tags: [haproxy]

--- a/ansible/roles/haproxy/templates/haproxy.bastion.cfg.j2
+++ b/ansible/roles/haproxy/templates/haproxy.bastion.cfg.j2
@@ -44,69 +44,69 @@ listen stats # Define a listen section called "stats"
 
 
 
-frontend {{ cluster.name }}-kubernetes-api-server
+frontend {{ cluster_name }}-kubernetes-api-server
     mode tcp
     option tcplog
     # option tcp-check
     # option forwardfor
-    bind api.{{ cluster.name }}.{{ cluster.fqdn }}:6443
-    default_backend {{ cluster.name }}-kubernetes-api-server
+    bind api.{{ cluster_name }}.{{ fqdn }}:6443
+    default_backend {{ cluster_name }}-kubernetes-api-server
 
-backend {{ cluster.name }}-kubernetes-api-server
+backend {{ cluster_name }}-kubernetes-api-server
     balance source
     mode tcp
-    server {{ cluster.nodes['bootstrap-0'].name }} {{ cluster.nodes['bootstrap-0'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:6443 check
-    server {{ cluster.nodes['master-0'].name }} {{ cluster.nodes['master-0'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:6443 check
-    server {{ cluster.nodes['master-1'].name }} {{ cluster.nodes['master-1'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:6443 check
-    server {{ cluster.nodes['master-2'].name }} {{ cluster.nodes['master-2'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:6443 check
+    server bootstrap-0 bootstrap-0.{{ cluster_name }}.{{ fqdn }}:6443 check
+    server master-0 master-0.{{ cluster_name }}.{{ fqdn }}:6443 check
+    server master-1 master-1.{{ cluster_name }}.{{ fqdn }}:6443 check
+    server master-2 master-2.{{ cluster_name }}.{{ fqdn }}:6443 check
 
 
 
-frontend {{ cluster.name }}-machine-config-server
+frontend {{ cluster_name }}-machine-config-server
     mode tcp
     option tcplog
     # option forwardfor
     # timeout client 1m
-    bind api.{{ cluster.name }}.{{ cluster.fqdn }}:22623
-    default_backend {{ cluster.name }}-machine-config-server
+    bind api.{{ cluster_name }}.{{ fqdn }}:22623
+    default_backend {{ cluster_name }}-machine-config-server
 
-backend {{ cluster.name }}-machine-config-server
+backend {{ cluster_name }}-machine-config-server
     balance source
     mode tcp
     # log global
     # timeout connect 10s
     # timeout server 1m
-    server {{ cluster.nodes['bootstrap-0'].name }} {{ cluster.nodes['bootstrap-0'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:22623 check
-    server {{ cluster.nodes['master-0'].name }} {{ cluster.nodes['master-0'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:22623 check
-    server {{ cluster.nodes['master-1'].name }} {{ cluster.nodes['master-1'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:22623 check
-    server {{ cluster.nodes['master-2'].name }} {{ cluster.nodes['master-2'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:22623 check
+    server bootstrap-0 bootstrap-0.{{ cluster_name }}.{{ fqdn }}:22623 check
+    server master-0 master-0.{{ cluster_name }}.{{ fqdn }}:22623 check
+    server master-1 master-1.{{ cluster_name }}.{{ fqdn }}:22623 check
+    server master-2 master-2.{{ cluster_name }}.{{ fqdn }}:22623 check
 
 
 
-frontend {{ cluster.name }}-router-http
+frontend {{ cluster_name }}-router-http
     mode tcp
     option tcplog
     # option forwardfor
-    bind apps.{{ cluster.name }}.{{ cluster.fqdn }}:80
-    default_backend {{ cluster.name }}-router-http
+    bind apps.{{ cluster_name }}.{{ fqdn }}:80
+    default_backend {{ cluster_name }}-router-http
 
-backend {{ cluster.name }}-router-http
+backend {{ cluster_name }}-router-http
     balance source
     mode tcp
-    server {{ cluster.nodes['infnod-0'].name }} {{ cluster.nodes['infnod-0'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:80 check
-    server {{ cluster.nodes['infnod-1'].name }} {{ cluster.nodes['infnod-1'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:80 check
+    server infnod-0 infnod-0.{{ cluster_name }}.{{ fqdn }}:80 check
+    server infnod-1 infnod-1.{{ cluster_name }}.{{ fqdn }}:80 check
 
 
 
-frontend {{ cluster.name }}-router-https
+frontend {{ cluster_name }}-router-https
     mode tcp
     option tcplog
     # option forwardfor
-    bind apps.{{ cluster.name }}.{{ cluster.fqdn }}:443
-    default_backend {{ cluster.name }}-router-https
+    bind apps.{{ cluster_name }}.{{ fqdn }}:443
+    default_backend {{ cluster_name }}-router-https
 
-backend {{ cluster.name }}-router-https
+backend {{ cluster_name }}-router-https
     balance source
     mode tcp
-    server {{ cluster.nodes['infnod-0'].name }} {{ cluster.nodes['infnod-0'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:443 check
-    server {{ cluster.nodes['infnod-1'].name }} {{ cluster.nodes['infnod-1'].name }}.{{ cluster.name }}.{{ cluster.fqdn }}:443 check
+    server infnod-0 infnod-0.{{ cluster_name }}.{{ fqdn }}:443 check
+    server infnod-1 infnod-1.{{ cluster_name }}.{{ fqdn }}:443 check

--- a/terraform/env/dev/main.tf
+++ b/terraform/env/dev/main.tf
@@ -23,6 +23,7 @@ module "bastion" {
   vault_addr      = "https://vault.oswee.com"
   vault_role_id   = module.vault-ssh.approle.role
   vault_secret_id = module.vault-ssh.approle.secret
+  user            = "ansible"
 }
 
 module "vault" {
@@ -31,4 +32,6 @@ module "vault" {
 
 module "vault-ssh" {
   source = "../../modules/vault-ssh"
+
+  user            = "ansible"
 }

--- a/terraform/modules/libvirt-domain/templates/cloud_init.tpl
+++ b/terraform/modules/libvirt-domain/templates/cloud_init.tpl
@@ -7,6 +7,7 @@ hostname: ${hostname}
 packages:
   - qemu-guest-agent
   - jq
+  - firewalld
 
 write_files:
   - content: |

--- a/terraform/modules/libvirt-domain/templates/cloud_init.tpl
+++ b/terraform/modules/libvirt-domain/templates/cloud_init.tpl
@@ -78,8 +78,7 @@ runcmd:
   - [ systemctl, restart, sshd.service ]
 
 users:
-  - name: ansible
-  - name: ops
+  - name: ${user}
     sudo: ['ALL=(ALL) NOPASSWD:ALL']
     groups: users, wheel
     shell: /bin/bash


### PR DESCRIPTION
At this point i am able to install HAProxy with Ansible.
It took some time to figure out how to let Jenkins connect to the hosts via SSH.
Basically i did that via placing client SSH certificates in `/var/lib/jenkins/.ssh` which also means i need some scripts to rotate them.
My current solution is to have SystemD timer unit which calls the bash script which does Vault authentication using AppRole and then signing the certificates. This is done daily by the timer.
Not sure is it the right way, but i didn't found the way how to pass Host CA public key into Ansible plugin.